### PR TITLE
Add Single reminder

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -7,7 +7,9 @@ const Router = Ember.Router.extend({
 });
 
 Router.map(function() {
-  this.route('reminders', {path: '/reminders'});
+  this.route('reminders', {path: '/reminders'}, function() {
+    this.route('reminder', {path: 'reminder/:reminder_id'});
+  });
 });
 
 export default Router;

--- a/app/router.js
+++ b/app/router.js
@@ -7,7 +7,7 @@ const Router = Ember.Router.extend({
 });
 
 Router.map(function() {
-  this.route('reminders', {path: '/reminders'}, function() {
+  this.route('reminders', function() {
     this.route('reminder', {path: 'reminder/:reminder_id'});
   });
 });

--- a/app/routes/reminders/reminder.js
+++ b/app/routes/reminders/reminder.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  model: (params) => {
+    return this.get('store').findRecord('reminder', params.id);
+  }
+});

--- a/app/templates/reminders.hbs
+++ b/app/templates/reminders.hbs
@@ -1,11 +1,12 @@
 <h2>Reminder page</h2>
+{{outlet}}
 
+<h3>All reminders</h3>
 {{#each model as |reminder|}}
+  {{#link-to "reminders.reminder" reminder}}
   <div class="reminder-item">
-    <h3>{{reminder.title}}</h3>
-    <p>{{reminder.date}}</p>
-    <p>{{reminder.notes}}</p>
+    <h4>{{reminder.title}}</h4>
   </div>
+  {{/link-to}}
 {{/each}}
 
-{{outlet}}

--- a/app/templates/reminders/reminder.hbs
+++ b/app/templates/reminders/reminder.hbs
@@ -1,0 +1,9 @@
+<h4>Selected Reminder</h4>
+
+<div class="reminder-single">
+  <h3 class="reminder-title">{{model.title}}</h3>
+  <p>{{model.date}}</p>
+  <p>{{model.notes}}</p>
+</div>
+
+{{outlet}}

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -18,14 +18,14 @@ test('viewing the homepage redirects to reminders page', function(assert) {
   });
 });
 
-// test('clicking on an individual item', function(assert) {
-//   server.createList('reminder', 5);
-//
-//   visit('/reminders');
-//   click('.reminder-item:first');
-//
-//   andThen(function() {
-//     assert.equal(currentURL(), '/reminders/reminder/1');
-//     assert.equal(Ember.$('.reminder-item:first').text().trim(), Ember.$('.reminder-title').text().trim());
-//   });
-// });
+test('clicking on an individual item', function(assert) {
+  server.createList('reminder', 5);
+
+  visit('/reminders');
+  click('.reminder-item:first');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/reminders/reminder/1');
+    assert.equal(Ember.$('.reminder-item:first').text().trim(), Ember.$('.reminder-title').text().trim());
+  });
+});


### PR DESCRIPTION
## Purpose

Add in single reminder functionality. Clears out details from main reminder list. User can click a reminder and it will be rendered with details above the list. closes #3 

## Approach

Add dynamic route to reminders/reminder/:id. Turns out Ember handles all that ID stuff for you!

### Learning
https://emberjs.com/api/data/classes/DS.Store.html#method_findRecord
This just happened to work!

### Follow-up tasks

Issue 4

### Screenshots

#### After

![image](https://cloud.githubusercontent.com/assets/5368526/24678023/1b5822d6-1946-11e7-8ec7-bb3dec5111e4.png)

@Tman22 @martensonbj 

