### PR TITLE
Add conditional to reminder loading

### DIFF
--- a/app/templates/reminders.hbs
+++ b/app/templates/reminders.hbs
@@ -1,18 +1,18 @@
 <h2>Reminder page</h2>
 {{outlet}}
 
-{{#if model}}
-  <h3>All reminders</h3>
-  {{#each model as |reminder|}}
-    {{#link-to "reminders.reminder" reminder}}
-    <div class="reminder-item">
-      <h4>{{reminder.title}}</h4>
-    </div>
-    {{/link-to}}
-  {{/each}}
+
+<h3>All reminders</h3>
+{{#each model as |reminder|}}
+  {{#link-to "reminders.reminder" reminder}}
+  <div class="reminder-item">
+    <h4>{{reminder.title}}</h4>
+  </div>
+  {{/link-to}}
 {{else}}
   <p class="no-reminders-notice">No reminders, click below to enter one.</p>
-{{/if}}
+{{/each}}
+
 
 {{#link-to "reminders.new"}}
   <button>Make a new Idea</button>

--- a/app/templates/reminders.hbs
+++ b/app/templates/reminders.hbs
@@ -1,14 +1,18 @@
 <h2>Reminder page</h2>
 {{outlet}}
 
-<h3>All reminders</h3>
-{{#each model as |reminder|}}
-  {{#link-to "reminders.reminder" reminder}}
-  <div class="reminder-item">
-    <h4>{{reminder.title}}</h4>
-  </div>
-  {{/link-to}}
-{{/each}}
+{{#if model}}
+  <h3>All reminders</h3>
+  {{#each model as |reminder|}}
+    {{#link-to "reminders.reminder" reminder}}
+    <div class="reminder-item">
+      <h4>{{reminder.title}}</h4>
+    </div>
+    {{/link-to}}
+  {{/each}}
+{{else}}
+  <p class="no-reminders-notice">No reminders, click below to enter one.</p>
+{{/if}}
 
 {{#link-to "reminders.new"}}
   <button>Make a new Idea</button>

--- a/mirage/scenarios/default.js
+++ b/mirage/scenarios/default.js
@@ -1,3 +1,3 @@
 export default function(server) {
-  server.createList('reminder', 5);
+  server.createList('reminder', 0);
 }

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -35,7 +35,7 @@ test('Display prompt if no reminders are present', function(assert) {
   visit('/reminders');
 
   andThen(function() {
-    assert.equal(Ember.$('.no-reminders-notice').length, 1);
+    assert.equal(find('.no-reminders-notice').length, 1);
   });
 });
 

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -29,3 +29,14 @@ test('clicking on an individual item', function(assert) {
     assert.equal(Ember.$('.reminder-item:first').text().trim(), Ember.$('.reminder-title').text().trim());
   });
 });
+
+test('Display prompt if no reminders are present', function(assert) {
+
+  visit('/reminders');
+
+  andThen(function() {
+    assert.equal(Ember.$('.no-reminders-notice').length, 1);
+  });
+});
+
+

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -31,7 +31,6 @@ test('clicking on an individual item', function(assert) {
 });
 
 test('Display prompt if no reminders are present', function(assert) {
-
   visit('/reminders');
 
   andThen(function() {


### PR DESCRIPTION
## Purpose

If no reminders are found, user is prompted to click the 'add new reminder' button. closes #5

## Approach

If statement does the trick here.

### Learning

found this
http://handlebarsjs.com/builtin_helpers.html

### Test coverage 

Added a test to check the prompt is rendered instead of the reminder list.

### Follow-up tasks

- #6

### Screenshots

#### After
![image](https://cloud.githubusercontent.com/assets/5368526/24712762/fc81e6b2-19e0-11e7-88ba-18be61a8724c.png)

@Tman22 @martensonbj 
