### PR TITLE
Add edit reminder

### DIFF
--- a/app/controllers/reminders/edit.js
+++ b/app/controllers/reminders/edit.js
@@ -1,0 +1,15 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  actions: {
+    updateReminder() {
+      const title = this.get('title');
+      const date = this.get('date');
+      const notes = this.get('notes');
+      this.get('store').findRecord('reminder', this.id)
+      .then((foundReminder) => {
+        foundReminder.set('title', title)
+      })
+    }
+  }
+});

--- a/app/controllers/reminders/edit.js
+++ b/app/controllers/reminders/edit.js
@@ -3,13 +3,9 @@ import Ember from 'ember';
 export default Ember.Controller.extend({
   actions: {
     updateReminder() {
-      const title = this.get('title');
-      const date = this.get('date');
-      const notes = this.get('notes');
-      this.get('store').findRecord('reminder', this.id)
-      .then((foundReminder) => {
-        foundReminder.set('title', title)
-      })
+      this.transitionToRoute('reminders')
     }
   }
 });
+
+

--- a/app/models/reminder.js
+++ b/app/models/reminder.js
@@ -3,5 +3,5 @@ import DS from 'ember-data';
 export default DS.Model.extend({
   title: DS.attr('string'),
   notes: DS.attr('string'),
-  date: DS.attr('date')
+  date: DS.attr('string')
 });

--- a/app/router.js
+++ b/app/router.js
@@ -10,6 +10,7 @@ Router.map(function() {
   this.route('reminders', function() {
     this.route('reminder', {path: 'reminder/:reminder_id'});
     this.route('new');
+    this.route('edit', {path: 'reminder/edit/:reminder_id'});
   });
 });
 

--- a/app/routes/reminders/edit.js
+++ b/app/routes/reminders/edit.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  model: (params) => {
+    return this.get('store').findRecord('reminder', params.id);
+  }
+});

--- a/app/templates/reminders/edit.hbs
+++ b/app/templates/reminders/edit.hbs
@@ -1,6 +1,6 @@
-<h2>Edit an old Reminder... in a box</h2>
-{{input id="title-input" value=model.title valueBinding="title" type="text" placeholder="Title"}}
-{{input id="date-input" value=model.title valueBinding="date" type="text" placeholder="Date"}}
-{{input id="notes-input" value=model.title valueBinding="notes" type="text" placeholder="Reminder"}}
-<!-- <button  id="add-reminder-button" {{action "saveReminder"}}>save reminder</button>
+<h5>Editing reminder</h5>
+{{input id="title-input" valueBinding=model.title type="text"}}
+{{input id="date-input" valueBinding=model.date type="text" }}
+{{input id="notes-input" valueBinding=model.notes type="text" }}
+<button  id="save-reminder-button" {{action "updateReminder"}}>save</button>
 

--- a/app/templates/reminders/edit.hbs
+++ b/app/templates/reminders/edit.hbs
@@ -1,0 +1,6 @@
+<h2>Edit an old Reminder... in a box</h2>
+{{input id="title-input" value=model.title valueBinding="title" type="text" placeholder="Title"}}
+{{input id="date-input" value=model.title valueBinding="date" type="text" placeholder="Date"}}
+{{input id="notes-input" value=model.title valueBinding="notes" type="text" placeholder="Reminder"}}
+<!-- <button  id="add-reminder-button" {{action "saveReminder"}}>save reminder</button>
+

--- a/app/templates/reminders/reminder.hbs
+++ b/app/templates/reminders/reminder.hbs
@@ -4,6 +4,9 @@
   <h3 class="reminder-title">{{model.title}}</h3>
   <p>{{model.date}}</p>
   <p>{{model.notes}}</p>
+  {{#link-to 'reminders.edit' model}}
+    <button>Edit</button>
+  {{/link-to}}
 </div>
 
 {{outlet}}

--- a/app/templates/reminders/reminder.hbs
+++ b/app/templates/reminders/reminder.hbs
@@ -5,7 +5,7 @@
   <p>{{model.date}}</p>
   <p>{{model.notes}}</p>
   {{#link-to 'reminders.edit' model}}
-    <button>Edit</button>
+    <button id="edit-reminder-button">Edit</button>
   {{/link-to}}
 </div>
 

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -38,4 +38,24 @@ test('Display prompt if no reminders are present', function(assert) {
   });
 });
 
+test('edit on an individual item', function(assert) {
+  server.createList('reminder', 1);
+
+  visit('/reminders');
+  click('.reminder-item:first');
+  click('#edit-reminder-button');
+
+  andThen(() => {
+    assert.equal(currentURL(), '/reminders/reminder/edit/1')
+  })
+
+  fillIn('#title-input', 'Remember this');
+  click('#save-reminder-button');
+  
+  andThen(function() {
+    assert.equal(currentURL(), '/reminders');
+    assert.equal(Ember.$('.reminder-item:first').text().trim(), 'Remember this');
+  });
+});
+
 


### PR DESCRIPTION
## Purpose

User can now click the edit button and edit reminder model. closes #6 

## Approach

I tried coding a bunch, then deleted most of it and editing worked. 

### Learning

This model thing seems to be directly updating data immediately. I assumed I'd have to handle the new input data but turns out it does that already somehow. It appears no explicit saving is required. 

### Test coverage 

New test confirms that after editing a reminder, the reminder is updated on redirect to favorites.

### Screenshots

#### After

![image](https://cloud.githubusercontent.com/assets/5368526/24727860/ce01e7f4-1a14-11e7-99c9-fa3f7f91571b.png)

@Tman22 @martensonbj 
