### PR TITLE
Delete reminder

### DIFF
--- a/app/controllers/reminders.js
+++ b/app/controllers/reminders.js
@@ -1,0 +1,10 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  actions: {
+    delete(reminder) {
+      reminder.destroyRecord()
+      this.transitionToRoute('reminders')
+    }
+  }
+});

--- a/app/controllers/reminders/edit.js
+++ b/app/controllers/reminders/edit.js
@@ -1,0 +1,15 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  actions: {
+    updateReminder() {
+      const title = this.get('title');
+      const date = this.get('date');
+      const notes = this.get('notes');
+      this.get('store').findRecord('reminder', this.id)
+      .then((foundReminder) => {
+        foundReminder.set('title', title)
+      })
+    }
+  }
+});

--- a/app/controllers/reminders/edit.js
+++ b/app/controllers/reminders/edit.js
@@ -3,13 +3,9 @@ import Ember from 'ember';
 export default Ember.Controller.extend({
   actions: {
     updateReminder() {
-      const title = this.get('title');
-      const date = this.get('date');
-      const notes = this.get('notes');
-      this.get('store').findRecord('reminder', this.id)
-      .then((foundReminder) => {
-        foundReminder.set('title', title)
-      })
+      this.transitionToRoute('reminders')
     }
   }
 });
+
+

--- a/app/controllers/reminders/reminder.js
+++ b/app/controllers/reminders/reminder.js
@@ -1,0 +1,10 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  actions: {
+    delete(reminder) {
+      reminder.destroyRecord()
+      this.transitionToRoute('reminders')
+    }
+  }
+});

--- a/app/models/reminder.js
+++ b/app/models/reminder.js
@@ -3,5 +3,5 @@ import DS from 'ember-data';
 export default DS.Model.extend({
   title: DS.attr('string'),
   notes: DS.attr('string'),
-  date: DS.attr('date')
+  date: DS.attr('string')
 });

--- a/app/router.js
+++ b/app/router.js
@@ -10,6 +10,7 @@ Router.map(function() {
   this.route('reminders', function() {
     this.route('reminder', {path: 'reminder/:reminder_id'});
     this.route('new');
+    this.route('edit', {path: 'reminder/edit/:reminder_id'});
   });
 });
 

--- a/app/routes/reminders/edit.js
+++ b/app/routes/reminders/edit.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  model: (params) => {
+    return this.get('store').findRecord('reminder', params.id);
+  }
+});

--- a/app/templates/reminders.hbs
+++ b/app/templates/reminders.hbs
@@ -4,18 +4,17 @@
 
 <h3>All reminders</h3>
 {{#each model as |reminder|}}
-  {{#link-to "reminders.reminder" reminder}}
   <div class="reminder-item">
+    {{#link-to "reminders.reminder" reminder}}
     <h4>{{reminder.title}}</h4>
-  </div>
-  {{/link-to}}
-  {{#link-to "reminders"}}
+    {{/link-to}}
     <button {{action "delete" reminder}}> Delete </button>
-  {{/link-to}}
+  </div>
 {{else}}
   <p class="no-reminders-notice">No reminders, click below to enter one.</p>
 {{/each}}
 
+<br>
 
 {{#link-to "reminders.new"}}
   <button>Make a new Idea</button>

--- a/app/templates/reminders.hbs
+++ b/app/templates/reminders.hbs
@@ -9,6 +9,9 @@
     <h4>{{reminder.title}}</h4>
   </div>
   {{/link-to}}
+  {{#link-to "reminders"}}
+    <button {{action "delete" reminder}}> Delete </button>
+  {{/link-to}}
 {{else}}
   <p class="no-reminders-notice">No reminders, click below to enter one.</p>
 {{/each}}

--- a/app/templates/reminders.hbs
+++ b/app/templates/reminders.hbs
@@ -4,12 +4,13 @@
 
 <h3>All reminders</h3>
 {{#each model as |reminder|}}
-  <div class="reminder-item">
-    {{#link-to "reminders.reminder" reminder}}
-    <h4>{{reminder.title}}</h4>
-    {{/link-to}}
-    <button {{action "delete" reminder}}> Delete </button>
-  </div>
+  {{#link-to "reminders.reminder" reminder}}
+    <div class="reminder-item">
+      <h4>{{reminder.title}}</h4>
+    </div>
+  {{/link-to}}
+  <button {{action "delete" reminder}} class="delete-reminder-button"> Delete </button>
+
 {{else}}
   <p class="no-reminders-notice">No reminders, click below to enter one.</p>
 {{/each}}

--- a/app/templates/reminders/edit.hbs
+++ b/app/templates/reminders/edit.hbs
@@ -1,6 +1,6 @@
-<h2>Edit an old Reminder... in a box</h2>
-{{input id="title-input" value=model.title valueBinding="title" type="text" placeholder="Title"}}
-{{input id="date-input" value=model.title valueBinding="date" type="text" placeholder="Date"}}
-{{input id="notes-input" value=model.title valueBinding="notes" type="text" placeholder="Reminder"}}
-<!-- <button  id="add-reminder-button" {{action "saveReminder"}}>save reminder</button>
+<h5>Editing reminder</h5>
+{{input id="title-input" valueBinding=model.title type="text"}}
+{{input id="date-input" valueBinding=model.date type="text" }}
+{{input id="notes-input" valueBinding=model.notes type="text" }}
+<button  id="save-reminder-button" {{action "updateReminder"}}>save</button>
 

--- a/app/templates/reminders/edit.hbs
+++ b/app/templates/reminders/edit.hbs
@@ -1,0 +1,6 @@
+<h2>Edit an old Reminder... in a box</h2>
+{{input id="title-input" value=model.title valueBinding="title" type="text" placeholder="Title"}}
+{{input id="date-input" value=model.title valueBinding="date" type="text" placeholder="Date"}}
+{{input id="notes-input" value=model.title valueBinding="notes" type="text" placeholder="Reminder"}}
+<!-- <button  id="add-reminder-button" {{action "saveReminder"}}>save reminder</button>
+

--- a/app/templates/reminders/reminder.hbs
+++ b/app/templates/reminders/reminder.hbs
@@ -7,6 +7,7 @@
   {{#link-to 'reminders.edit' model}}
     <button id="edit-reminder-button">Edit</button>
   {{/link-to}}
+  <button {{action "delete" model}}> Delete </button>
 </div>
 
 {{outlet}}

--- a/app/templates/reminders/reminder.hbs
+++ b/app/templates/reminders/reminder.hbs
@@ -4,6 +4,9 @@
   <h3 class="reminder-title">{{model.title}}</h3>
   <p>{{model.date}}</p>
   <p>{{model.notes}}</p>
+  {{#link-to 'reminders.edit' model}}
+    <button>Edit</button>
+  {{/link-to}}
 </div>
 
 {{outlet}}

--- a/app/templates/reminders/reminder.hbs
+++ b/app/templates/reminders/reminder.hbs
@@ -5,7 +5,7 @@
   <p>{{model.date}}</p>
   <p>{{model.notes}}</p>
   {{#link-to 'reminders.edit' model}}
-    <button>Edit</button>
+    <button id="edit-reminder-button">Edit</button>
   {{/link-to}}
 </div>
 

--- a/app/templates/reminders/reminder.hbs
+++ b/app/templates/reminders/reminder.hbs
@@ -7,7 +7,7 @@
   {{#link-to 'reminders.edit' model}}
     <button id="edit-reminder-button">Edit</button>
   {{/link-to}}
-  <button {{action "delete" model}}> Delete </button>
+  <button {{action "delete" model}} class="delete-reminder-button"> Delete </button>
 </div>
 
 {{outlet}}

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -38,4 +38,24 @@ test('Display prompt if no reminders are present', function(assert) {
   });
 });
 
+test('edit on an individual item', function(assert) {
+  server.createList('reminder', 1);
+
+  visit('/reminders');
+  click('.reminder-item:first');
+  click('#edit-reminder-button');
+
+  andThen(() => {
+    assert.equal(currentURL(), '/reminders/reminder/edit/1')
+  })
+
+  fillIn('#title-input', 'Remember this');
+  click('#save-reminder-button');
+  
+  andThen(function() {
+    assert.equal(currentURL(), '/reminders');
+    assert.equal(Ember.$('.reminder-item:first').text().trim(), 'Remember this');
+  });
+});
+
 

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -12,7 +12,7 @@ test('viewing the homepage redirects to reminders page', function(assert) {
 
   visit('/');
 
-  andThen(function() {
+  andThen(() => {
     assert.equal(currentURL(), '/reminders');
     assert.equal(Ember.$('.reminder-item').length, 5);
   });
@@ -24,7 +24,7 @@ test('clicking on an individual item', function(assert) {
   visit('/reminders');
   click('.reminder-item:first');
 
-  andThen(function() {
+  andThen(() => {
     assert.equal(currentURL(), '/reminders/reminder/1');
     assert.equal(Ember.$('.reminder-item:first').text().trim(), Ember.$('.reminder-title').text().trim());
   });
@@ -33,7 +33,7 @@ test('clicking on an individual item', function(assert) {
 test('Display prompt if no reminders are present', function(assert) {
   visit('/reminders');
 
-  andThen(function() {
+  andThen(() => {
     assert.equal(find('.no-reminders-notice').length, 1);
   });
 });
@@ -51,11 +51,34 @@ test('edit on an individual item', function(assert) {
 
   fillIn('#title-input', 'Remember this');
   click('#save-reminder-button');
-  
-  andThen(function() {
+
+  andThen(() => {
     assert.equal(currentURL(), '/reminders');
     assert.equal(Ember.$('.reminder-item:first').text().trim(), 'Remember this');
   });
+});
+
+test('Delete on an individual item from the list', function(assert) {
+  server.createList('reminder', 3);
+
+  visit('/reminders');
+  click('.delete-reminder-button:first');
+
+  andThen(() => {
+    assert.equal(Ember.$('.reminder-item').length, 2);
+  })
+});
+
+test('Delete on an individual item from the single view', function(assert) {
+  server.createList('reminder', 3);
+
+  visit('/reminders');
+  click('.reminder-item:first');
+  click('.delete-reminder-button:first');
+
+  andThen(() => {
+    assert.equal(Ember.$('.reminder-item').length, 2);
+  })
 });
 
 


### PR DESCRIPTION
## Purpose

User can now delete reminders from the store. closes #9 

## Approach

Adds delete button and actions for both list of reminders and single page reminders. 

### Test coverage 

Added two tests, for each new delete button.

### Follow-up tasks

Burn everything I own, leave the country. 

### Screenshots

#### After
![image](https://cloud.githubusercontent.com/assets/5368526/24730813/2b418eb6-1a23-11e7-9895-371df7d1a38b.png)

![image](https://cloud.githubusercontent.com/assets/5368526/24730817/3317a652-1a23-11e7-8eb8-7b2c34b664de.png)


